### PR TITLE
feat(config): update deprecated flow

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,7 +1,6 @@
 name: Validate integration
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
@@ -11,13 +10,13 @@ jobs:
     name: Hassfest
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: home-assistant/actions/hassfest@master
   hacs:
     name: HACS Action
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: HACS Action
         uses: hacs/action@main
         with:

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ This integration provides support for some of [KernelChip] devices.
 Install it as [Custom repository] within HACS and activate it from UI. You've to provide unique name for your device,
 host and password (passwordless access is not supported).
 
-Поддерживается настройка через UI (ConfigFlow), нужно указать хост и пароль от устройства.
-
 ## Roadmap
 
-I've made this integration for my only KernelChip's device ([Laurent-112]). According to documentation, this integration may also support [Laurent-128] but I haven't tested it. I don't have any plans supporting other devices.
+I've made this integration for my only KernelChip's device ([Laurent-112]). According to documentation, this integration
+may also support [Laurent-128] but I haven't tested it. I don't have any plans supporting other devices.
 
 You may send PR to provide support for other devices, or just fork it.
 

--- a/custom_components/laurent/config_flow.py
+++ b/custom_components/laurent/config_flow.py
@@ -5,10 +5,10 @@ import voluptuous as vol
 from homeassistant.config_entries import (
     ConfigFlow,
     ConfigEntry,
-    OptionsFlow
+    OptionsFlow,
+    ConfigFlowResult,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.const import (
     CONF_NAME,
     CONF_HOST,
@@ -31,11 +31,11 @@ class LaurentConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        return LaurentOptionsFlowHandler(config_entry)
+        return LaurentOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -58,12 +58,9 @@ class LaurentConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class LaurentOptionsFlowHandler(OptionsFlow):
-    def __init__(self, config_entry: ConfigFlow) -> None:
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         errors: dict[str, str] = {}
 
         if user_input is not None:

--- a/custom_components/laurent/const.py
+++ b/custom_components/laurent/const.py
@@ -6,6 +6,6 @@ DOMAIN: Final = "laurent"
 MANUFACTURER: Final = "KernelChip"
 
 DEFAULT_NAME: Final = "Laurent"
-DEFAULT_HOST: Final = "192.168.0.101"
+DEFAULT_HOST: Final = "http://192.168.0.101"
 DEFAULT_PASSWORD: Final = "Laurent"
 DEFAULT_SCAN_INTERVAL: Final = 5

--- a/custom_components/laurent/manifest.json
+++ b/custom_components/laurent/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/leonidboykov/ha-laurent/issues",
   "requirements": [],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
This PR addresses an issue:

```
Detected that custom integration 'laurent' sets option flow config_entry explicitly, which is deprecated at custom_components/laurent/config_flow.py, line 62: self.config_entry = config_entry.
```